### PR TITLE
Improve console UI

### DIFF
--- a/src/app/console/[appId]/page.tsx
+++ b/src/app/console/[appId]/page.tsx
@@ -1,6 +1,7 @@
 import { createApplication, getApplications } from "@/lib/server/console";
 import ApplicationCard from "@/components/console/ApplicationCard";
 import { getAccessToken } from "@auth0/nextjs-auth0";
+import { PlusIcon } from "@heroicons/react/24/outline";
 
 export const dynamic = "force-dynamic";
 
@@ -18,11 +19,13 @@ export default async function ConsolePage() {
       <div className="flex justify-between items-center mb-6">
         <h2 className="text-2xl font-bold text-gray-800">Applications</h2>
         <form action={handleSubmit}>
-          <input
+          <button
             type="submit"
-            value="New Application"
-            className="bg-blue-500 hover:bg-blue-600 cursor-pointer text-white px-4 py-2 rounded-md"
-          />
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md flex items-center"
+          >
+            <PlusIcon className="h-5 w-5 mr-2" />
+            New Application
+          </button>
         </form>
       </div>
 

--- a/src/app/console/page.tsx
+++ b/src/app/console/page.tsx
@@ -1,6 +1,6 @@
 import { getApplications, createApplication } from "@/lib/server/console";
 import { redirect } from "next/navigation";
-import { RocketLaunchIcon } from "@heroicons/react/24/outline";
+import { RocketLaunchIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 
 export default async function WelcomeConsolePage() {
@@ -32,6 +32,7 @@ export default async function WelcomeConsolePage() {
             type="submit"
             className="inline-flex items-center px-6 py-3 border border-transparent text-lg font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-sm transition-colors duration-200"
           >
+            <PlusIcon className="h-5 w-5 mr-2" />
             Create Your First Application
           </button>
         </form>

--- a/src/components/EditableLabel.tsx
+++ b/src/components/EditableLabel.tsx
@@ -3,10 +3,15 @@ import { useState, useRef, useEffect } from "react";
 type EditableLabelProps = {
   value: string;
   onEdit: (newValue: string) => Promise<void>;
+  autoEdit?: boolean;
 };
 
-export default function EditableLabel({ value, onEdit }: EditableLabelProps) {
-  const [isEditing, setIsEditing] = useState(false);
+export default function EditableLabel({
+  value,
+  onEdit,
+  autoEdit = false,
+}: EditableLabelProps) {
+  const [isEditing, setIsEditing] = useState(autoEdit);
   const [inputValue, setInputValue] = useState(value);
   const [isLoading, setIsLoading] = useState(false);
   const [originalValue] = useState(value);
@@ -71,7 +76,7 @@ export default function EditableLabel({ value, onEdit }: EditableLabelProps) {
   return (
     <h3
       onClick={() => setIsEditing(true)}
-      className="font-medium text-gray-700 border border-transparent cursor-pointer hover:text-gray-900 px-1 py-0.5"
+      className="font-semibold text-gray-700 text-lg border border-transparent cursor-pointer hover:text-gray-900 px-1 py-0.5"
     >
       {inputValue}
     </h3>

--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -15,9 +15,10 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
 
   return (
     <div className="border border-gray-200 rounded-lg shadow-sm bg-white">
-      <div className="px-4 flex items-center justify-between">
+      <div className="px-4 py-4 flex items-center justify-between">
         <EditableLabel
           value={app.name ?? "New Application"}
+          autoEdit={!app.name || app.name === "New Application"}
           onEdit={async (newName) =>
             await updateApplication(app.id, { name: newName })
           }


### PR DESCRIPTION
## Summary
- add `autoEdit` option to `EditableLabel` and tweak styling
- show edit input automatically when creating a new application
- spruce up create buttons with icons
- minor layout touch ups

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688789819e90832d859ffad9917322e5