### PR TITLE
Revamp console UI

### DIFF
--- a/src/app/console/[appId]/page.tsx
+++ b/src/app/console/[appId]/page.tsx
@@ -16,12 +16,15 @@ export default async function ConsolePage() {
 
   return (
     <>
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-800">Applications</h2>
-        <form action={handleSubmit}>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8">
+        <div>
+          <h2 className="text-3xl font-bold text-gray-900">Your Applications</h2>
+          <p className="text-gray-600">Manage and create applications for your integration</p>
+        </div>
+        <form action={handleSubmit} className="mt-4 sm:mt-0">
           <button
             type="submit"
-            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md flex items-center"
+            className="bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded-lg shadow flex items-center"
           >
             <PlusIcon className="h-5 w-5 mr-2" />
             New Application
@@ -29,7 +32,7 @@ export default async function ConsolePage() {
         </form>
       </div>
 
-      <div className="space-y-4">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {apps.map((app) => (
           <ApplicationCard key={app.id} app={app} />
         ))}

--- a/src/components/EditableLabel.tsx
+++ b/src/components/EditableLabel.tsx
@@ -76,7 +76,7 @@ export default function EditableLabel({
   return (
     <h3
       onClick={() => setIsEditing(true)}
-      className="font-semibold text-gray-700 text-lg border border-transparent cursor-pointer hover:text-gray-900 px-1 py-0.5"
+      className="font-semibold text-gray-800 text-xl border border-transparent cursor-pointer hover:text-gray-900 px-1 py-0.5 transition-colors"
     >
       {inputValue}
     </h3>

--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import EditableLabel from "../EditableLabel";
+import Link from "next/link";
 import { deleteApplication, updateApplication } from "@/lib/server/console";
 import { Application } from "@/lib/server/types";
 
@@ -14,8 +15,8 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="border border-gray-200 rounded-lg shadow-sm bg-white">
-      <div className="px-4 py-4 flex items-center justify-between">
+    <div className="border border-gray-200 rounded-xl shadow bg-white transition-shadow hover:shadow-md">
+      <div className="px-6 py-4 flex items-center justify-between">
         <EditableLabel
           value={app.name ?? "New Application"}
           autoEdit={!app.name || app.name === "New Application"}
@@ -23,35 +24,34 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
             await updateApplication(app.id, { name: newName })
           }
         />
-        <div
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="flex-grow self-stretch cursor-pointer"
-        ></div>
+        <div className="flex-grow" onClick={() => setIsExpanded(!isExpanded)}></div>
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="my-4 text-gray-500 hover:text-gray-700"
+          className="text-gray-500 hover:text-gray-700 transition-transform"
         >
-          {isExpanded ? (
-            <ChevronUpIcon className="h-5 w-5" />
-          ) : (
-            <ChevronDownIcon className="h-5 w-5" />
-          )}
+          <ChevronDownIcon
+            className={`h-5 w-5 transform ${isExpanded ? "rotate-180" : ""}`}
+          />
         </button>
       </div>
 
       {isExpanded && (
-        <div className="border-t border-gray-200 p-4 bg-gray-50">
-          <div className="flex justify-end">
-            <form action={deleteApplication.bind(null, app.id)}>
-              <input type="hidden" name="id" value={app.id} />
-              <button
-                type="submit"
-                className="bg-red-600 text-white p-1 px-3 rounded hover:bg-red-700 text-sm font-medium"
-              >
-                Delete Application
-              </button>
-            </form>
-          </div>
+        <div className="border-t border-gray-200 px-6 py-4 bg-gray-50 flex items-center justify-between">
+          <Link
+            href={`/console/${app.id}/api-keys`}
+            className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            Manage API Keys
+          </Link>
+          <form action={deleteApplication.bind(null, app.id)}>
+            <input type="hidden" name="id" value={app.id} />
+            <button
+              type="submit"
+              className="text-sm text-red-600 hover:text-red-700 font-medium"
+            >
+              Delete Application
+            </button>
+          </form>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- modernize application card styles
- show API key management link and update delete button design
- improve application list layout
- enlarge editable label styling

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68879c86428c832d853b8d3b270bce40