### PR TITLE
Fix auto-selection of app names on console page

### DIFF
--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -19,7 +19,6 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
       <div className="px-6 py-4 flex items-center justify-between">
         <EditableLabel
           value={app.name ?? "New Application"}
-          autoEdit={!app.name || app.name === "New Application"}
           onEdit={async (newName) =>
             await updateApplication(app.id, { name: newName })
           }


### PR DESCRIPTION
## Summary
- avoid automatically focusing application name on console cards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a2a47140832d967834300d976858