### PR TITLE
Improve global styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,23 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
-/* :root {
+:root {
     --background: #ffffff;
     --foreground: #171717;
-} */
+}
 
-/* @media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
     :root {
         --background: #0a0a0a;
-        --foreground: #0a0a0a;
         --foreground: #ededed;
     }
-} */
+}
 
 body {
-    /* color: var(--foreground);
-    background: var(--background); */
-    font-family: Arial, Helvetica, sans-serif;
+    color: var(--foreground);
+    background: var(--background);
+    font-family: var(--font-geist-sans);
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <UserProvider>
         <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+          className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground dark:bg-background dark:text-foreground`}
         >
           {children}
         </body>


### PR DESCRIPTION
## Summary
- enable CSS custom properties for foreground/background
- hook fonts via CSS variable
- support dark mode via classes on body

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc39dfd8832d83f30880f153c9b0