### PR TITLE
Add responsive sidebar toggle

### DIFF
--- a/src/app/console/[appId]/layout.tsx
+++ b/src/app/console/[appId]/layout.tsx
@@ -1,5 +1,6 @@
 import Sidebar from "@/components/sidebar/Sidebar";
 import Topbar from "@/components/topbar/Topbar";
+import { SidebarProvider } from "@/components/sidebar/SidebarContext";
 import { getApplications } from "@/lib/server/console";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 import { redirect } from "next/navigation";
@@ -18,15 +19,17 @@ export default async function DashboardLayout({
   }
 
   return (
-    <div className="flex h-screen">
-      <Sidebar appId={params.appId} />
+    <SidebarProvider>
+      <div className="flex h-screen">
+        <Sidebar appId={params.appId} />
 
-      <div className="flex-1 p-2">
-        <div className="bg-white rounded-3xl shadow-sm h-[calc(100vh-1rem)] flex flex-col">
-          <Topbar />
-          <main className="flex-1 overflow-auto p-8 shadow-md">{children}</main>
+        <div className="flex-1 p-2">
+          <div className="bg-white rounded-3xl shadow-sm h-[calc(100vh-1rem)] flex flex-col">
+            <Topbar />
+            <main className="flex-1 overflow-auto p-8 shadow-md">{children}</main>
+          </div>
         </div>
       </div>
-    </div>
+    </SidebarProvider>
   );
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,13 +1,20 @@
+"use client";
+
 import NavList from "./NavList";
 import NavItem from "./NavItem";
+import { useSidebar } from "./SidebarContext";
 
 type SidebarProps = {
   appId?: string;
 };
 
 export default function Sidebar({ appId }: SidebarProps) {
+  const { open } = useSidebar();
+
   return (
-    <aside className="w-64 bg-white shadow-lg flex-shrink-0">
+    <aside
+      className={`fixed inset-y-0 left-0 z-40 w-64 bg-white shadow-lg flex-shrink-0 transform transition-transform md:relative md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+    >
       <div className="p-6">
         <h1 className="text-2xl font-bold text-gray-800">Gotcha console</h1>
       </div>

--- a/src/components/sidebar/SidebarContext.tsx
+++ b/src/components/sidebar/SidebarContext.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+export type SidebarContextType = {
+  open: boolean;
+  toggle: () => void;
+  close: () => void;
+};
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const toggle = () => setOpen((o) => !o);
+  const close = () => setOpen(false);
+  return (
+    <SidebarContext.Provider value={{ open, toggle, close }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) {
+    throw new Error("useSidebar must be used within SidebarProvider");
+  }
+  return ctx;
+}

--- a/src/components/topbar/MenuButton.tsx
+++ b/src/components/topbar/MenuButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Bars3Icon } from "@heroicons/react/24/outline";
+import { useSidebar } from "../sidebar/SidebarContext";
+
+export default function MenuButton() {
+  const { toggle } = useSidebar();
+  return (
+    <button
+      onClick={toggle}
+      className="md:hidden text-gray-600 hover:text-gray-900 mr-2"
+    >
+      <Bars3Icon className="h-6 w-6" />
+    </button>
+  );
+}

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -1,6 +1,7 @@
 import { getAccessToken, getSession } from "@auth0/nextjs-auth0";
 import { ApplicationSelector } from "./ApplicationSelector";
 import { getApplications } from "@/lib/server/console";
+import MenuButton from "./MenuButton";
 
 export default async function Topbar() {
   const [tokenRes, session] = await Promise.all([
@@ -10,8 +11,9 @@ export default async function Topbar() {
   const appsList = await getApplications(tokenRes.accessToken!!);
 
   return (
-    <header className="px-8 h-16 flex items-center justify-between border-b border-gray-100 flex-shrink-0">
-      <div className="text-gray-600">
+    <header className="px-4 h-16 flex items-center justify-between border-b border-gray-100 flex-shrink-0">
+      <div className="flex items-center text-gray-600">
+        <MenuButton />
         <ApplicationSelector appsList={appsList} />
       </div>
       <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- enable sidebar toggle with context
- add mobile menu button
- wrap console layout with sidebar provider

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc478830832d83b7c68dce9e5f6e