### PR TITLE
Improve accessibility for dropdown and toast

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useState, useRef, useEffect, PropsWithChildren } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  PropsWithChildren,
+  cloneElement,
+  ReactElement,
+  Children,
+  forwardRef,
+} from "react";
 
 type DropdownProps = PropsWithChildren<{
   label?: string;
@@ -15,7 +24,9 @@ export function Dropdown({
   className = "",
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<Array<HTMLLIElement | null>>([]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -24,12 +35,75 @@ export function Dropdown({
         !dropdownRef.current.contains(event.target as Node)
       ) {
         setIsOpen(false);
+        setFocusedIndex(-1);
       }
     }
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  useEffect(() => {
+    if (isOpen && focusedIndex >= 0) {
+      optionRefs.current[focusedIndex]?.focus();
+    }
+  }, [focusedIndex, isOpen]);
+
+  const optionElements = Children.toArray(children).map((child, index) =>
+    cloneElement(child as ReactElement, {
+      ref: (el: HTMLLIElement) => {
+        optionRefs.current[index] = el;
+      },
+      tabIndex: focusedIndex === index ? 0 : -1,
+      onKeyDown: (e: React.KeyboardEvent<HTMLLIElement>) =>
+        handleOptionKeyDown(e, index),
+    }),
+  );
+
+  function handleButtonKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!isOpen) {
+        setIsOpen(true);
+        setFocusedIndex(0);
+      } else {
+        setFocusedIndex((prev) => {
+          const dir = e.key === "ArrowDown" ? 1 : -1;
+          const count = optionRefs.current.length;
+          const next = prev + dir;
+          if (next < 0) return count - 1;
+          if (next >= count) return 0;
+          return next;
+        });
+      }
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+      setFocusedIndex(-1);
+    }
+  }
+
+  function handleOptionKeyDown(
+    e: React.KeyboardEvent<HTMLLIElement>,
+    index: number,
+  ) {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((prev) => {
+        const dir = e.key === "ArrowDown" ? 1 : -1;
+        const count = optionRefs.current.length;
+        const next = index + dir;
+        if (next < 0) return count - 1;
+        if (next >= count) return 0;
+        return next;
+      });
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+      setFocusedIndex(-1);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).click();
+    }
+  }
 
   return (
     <div
@@ -39,7 +113,13 @@ export function Dropdown({
       {label && <label className="sr-only">{label}</label>}
 
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          setIsOpen(!isOpen);
+          setFocusedIndex(0);
+        }}
+        onKeyDown={handleButtonKeyDown}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
         className="appearance-none bg-transparent border border-gray-300 rounded-md py-1.5 pl-3 pr-8 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 w-44 text-left"
       >
         {value || "Select option"}
@@ -60,8 +140,11 @@ export function Dropdown({
       </svg>
 
       {isOpen && (
-        <ol className="absolute top-full left-0 mt-1 bg-white border border-gray-300 rounded-md shadow-lg z-10">
-          {children}
+        <ol
+          role="listbox"
+          className="absolute top-full left-0 mt-1 bg-white border border-gray-300 rounded-md shadow-lg z-10"
+        >
+          {optionElements}
         </ol>
       )}
     </div>
@@ -73,15 +156,18 @@ type DropdownOptionProps = PropsWithChildren<{
   className?: string;
 }>;
 
-export function DropdownOption({
-  children,
-  className = "",
-}: DropdownOptionProps) {
-  return (
-    <li
-      className={`block overflow-x-hidden text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 cursor-pointer ${className}`}
-    >
-      {children}
-    </li>
-  );
-}
+export const DropdownOption = forwardRef<HTMLLIElement, DropdownOptionProps>(
+  ({ children, className = "" }, ref) => {
+    return (
+      <li
+        ref={ref}
+        role="option"
+        tabIndex={-1}
+        className={`block overflow-x-hidden text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 cursor-pointer ${className}`}
+      >
+        {children}
+      </li>
+    );
+  },
+);
+DropdownOption.displayName = "DropdownOption";

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -23,6 +23,8 @@ export default function Toast({
         transform transition-all duration-200
         ${show ? "opacity-100 translate-y-0" : "invisible opacity-0 translate-y-1 pointer-events-none"}
       `}
+      role="alert"
+      aria-live="assertive"
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary
- update dropdown with ARIA attributes
- support basic keyboard navigation for dropdown items
- add role and aria-live attributes to toast

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc3a7f24832d91971405ede48d31