### PR TITLE
Improve dark theme nav highlighting

### DIFF
--- a/src/components/sidebar/NavItem.tsx
+++ b/src/components/sidebar/NavItem.tsx
@@ -19,10 +19,10 @@ export default function NavItem({ href, children }: NavItemProps) {
   return (
     <Link
       href={href}
-      className={`flex items-center px-6 py-3 ${
+      className={`flex items-center px-6 py-3 rounded-md transition-colors ${
         isActive
-          ? "bg-gray-100 text-gray-900"
-          : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+          ? "bg-gray-700 text-white"
+          : "text-gray-300 hover:bg-gray-600 hover:text-white"
       }`}
     >
       {children}


### PR DESCRIPTION
## Summary
- use dark theme classes for active nav items
- rely on `usePathname` to decide the active route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e8e0ca50832db5fc6b1d2320154d