### PR TITLE
Switch default theme to dark

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-    --background: #ffffff;
-    --foreground: #171717;
-    color-scheme: light;
+    --background: #0a0a0a;
+    --foreground: #ededed;
+    color-scheme: dark;
 }
 
 @media (prefers-color-scheme: light) {
     :root {
-        --background: #0a0a0a;
-        --foreground: #ededed;
-        color-scheme: dark;
+        --background: #ffffff;
+        --foreground: #171717;
+        color-scheme: light;
     }
 }
 


### PR DESCRIPTION
## Summary
- default to dark colors in `globals.css`
- adjust light theme values

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688808dc08e4832da45fe390906674fc