### PR TITLE
Fix sidebar label text

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -22,7 +22,7 @@ export default function Sidebar({ appId }: SidebarProps) {
       <NavList>
         <NavItem href={`/console/${appId ?? ""}`}>
           <span className="mr-3">🏠</span>
-          Console
+          Applications
         </NavItem>
         <NavItem href={`/console/${appId ?? ""}/api-keys`}>
           <span className="mr-3">🔐</span>


### PR DESCRIPTION
## Summary
- update first sidebar navigation label from `Console` to `Applications`

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688808ddb3b4832d823deb1c10e41ae0