### PR TITLE
Fix sidebar dark background

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ export default function Sidebar({ appId }: SidebarProps) {
 
   return (
     <aside
-      className={`fixed inset-y-0 left-0 z-40 w-64 bg-background shadow-lg flex-shrink-0 transform transition-transform md:relative md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+      className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-gray-900 shadow-lg flex-shrink-0 transform transition-transform md:relative md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
     >
       <div className="p-6">
         <img src="https://gotcha.land/HL_2.png" alt="Gotcha logo" className="h-8" />


### PR DESCRIPTION
## Summary
- sidebar was using the generic background variable, which appeared white for some users
- set explicit dark color classes on the sidebar so it matches the rest of the layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880b893190832d825d0d0db1e7ab0d