### PR TITLE
Refine dashboard dark theme

### DIFF
--- a/src/app/console/[appId]/layout.tsx
+++ b/src/app/console/[appId]/layout.tsx
@@ -23,11 +23,9 @@ export default async function DashboardLayout({
       <div className="flex h-screen">
         <Sidebar appId={params.appId} />
 
-        <div className="flex-1 p-2">
-          <div className="bg-white dark:bg-gray-900 rounded-3xl shadow-sm h-[calc(100vh-1rem)] flex flex-col">
-            <Topbar />
-            <main className="flex-1 overflow-auto p-8 shadow-md">{children}</main>
-          </div>
+        <div className="flex-1 flex flex-col bg-white dark:bg-background">
+          <Topbar />
+          <main className="flex-1 overflow-auto p-8">{children}</main>
         </div>
       </div>
     </SidebarProvider>

--- a/src/components/api-keys/ApiKeyCard.tsx
+++ b/src/components/api-keys/ApiKeyCard.tsx
@@ -20,7 +20,7 @@ export default function ApiKeyCard({ apiKey, onEdit }: ApiKeyCardProps) {
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+    <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700/60">
       <div className="flex justify-between items-center mb-4">
         <EditableLabel
           value={apiKey.label ?? "New API key"}

--- a/src/components/challenge-preferences/ChallengePreferencesCard.tsx
+++ b/src/components/challenge-preferences/ChallengePreferencesCard.tsx
@@ -32,7 +32,7 @@ export default function ChallengePreferencesCard({
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700/60">
       <div className="flex justify-between items-center mb-6">
         <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
           Challenge Display Settings
@@ -66,7 +66,7 @@ export default function ChallengePreferencesCard({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Desktop Dimensions */}
         <div className="space-y-4">
-          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b pb-2">
+          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700/60 pb-2">
             Desktop Dimensions
           </h4>
           <div className="space-y-3">
@@ -123,7 +123,7 @@ export default function ChallengePreferencesCard({
 
         {/* Mobile Dimensions */}
         <div className="space-y-4">
-          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b pb-2">
+          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700/60 pb-2">
             Mobile Dimensions
           </h4>
           <div className="space-y-3">
@@ -180,7 +180,7 @@ export default function ChallengePreferencesCard({
 
         {/* Logo URL - spans full width */}
         <div className="md:col-span-2 space-y-4">
-          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b pb-2">Branding</h4>
+          <h4 className="font-medium text-gray-700 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700/60 pb-2">Branding</h4>
           <div>
             <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
               Logo URL

--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -13,7 +13,7 @@ type ApplicationCardProps = {
 export default function ApplicationCard({ app }: ApplicationCardProps) {
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-xl shadow bg-white dark:bg-gray-800 transition-shadow hover:shadow-md">
+    <div className="border border-gray-200 dark:border-gray-700/60 rounded-xl shadow-sm bg-white dark:bg-gray-800 transition-shadow hover:shadow">
       <div className="px-6 py-4 flex items-center justify-between">
         <EditableLabel
           value={app.name ?? "New Application"}
@@ -22,7 +22,7 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
         />
         <div className="flex-grow"></div>
       </div>
-      <div className="border-t border-gray-700 px-6 py-4 bg-gray-800 flex items-center justify-between">
+      <div className="border-t border-gray-700/60 px-6 py-4 bg-gray-800 flex items-center justify-between">
 
         <Link
           href={`/console/${app.id}/api-keys`}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ export default function Sidebar({ appId }: SidebarProps) {
 
   return (
     <aside
-      className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-gray-900 shadow-lg flex-shrink-0 transform transition-transform md:relative md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+      className={`fixed inset-y-0 left-0 z-40 w-64 bg-white dark:bg-background border-r border-gray-200 dark:border-gray-700/60 flex-shrink-0 transform transition-transform md:relative md:translate-x-0 ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
     >
       <div className="p-6">
         <img src="https://gotcha.land/HL_2.png" alt="Gotcha logo" className="h-8" />

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -11,7 +11,7 @@ export default async function Topbar() {
   const appsList = await getApplications(tokenRes.accessToken!!);
 
   return (
-    <header className="px-4 h-16 flex items-center justify-between border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 flex-shrink-0">
+    <header className="px-4 h-16 flex items-center justify-between border-b border-gray-200 dark:border-gray-700/50 bg-white dark:bg-background flex-shrink-0">
       <div className="flex items-center text-gray-600 dark:text-gray-300">
         <MenuButton />
         <ApplicationSelector appsList={appsList} />


### PR DESCRIPTION
## Summary
- use more subtle borders and shadows for cards
- dim topbar border opacity
- remove bright lines in challenge preferences
- remove remaining light gaps in dashboard

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880daedf28832d9d173fb7e1548d41