### PR TITLE
Show API keys grouped by application

### DIFF
--- a/src/app/console/[appId]/api-keys/page.tsx
+++ b/src/app/console/[appId]/api-keys/page.tsx
@@ -4,6 +4,7 @@ import {
   getApiKeys,
   updateApiKey,
 } from "@/lib/server/api-keys";
+import { getApplications } from "@/lib/server/console";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 
 export const dynamic = "force-dynamic";
@@ -14,46 +15,60 @@ export default async function ApiKeysPage({
   params: { appId: string };
 }) {
   const accessToken = (await getAccessToken()).accessToken!!;
-  const apiKeys = await getApiKeys(accessToken, params.appId);
+  const apps = await getApplications(accessToken);
+  const keysByApp = await Promise.all(
+    apps.map(async (a) => ({ app: a, keys: await getApiKeys(accessToken, a.id) }))
+  );
 
-  async function handleGenKey() {
+  async function handleGenKey(appId: string) {
     "use server";
-    return await generateApiKey(params.appId);
+    return await generateApiKey(appId);
   }
 
-  async function handleEditKey(siteKey: string, label: string) {
+  async function handleEditKey(appId: string, siteKey: string, label: string) {
     "use server";
-    return await updateApiKey(params.appId, siteKey, { name: label });
+    return await updateApiKey(appId, siteKey, { name: label });
   }
 
   return (
     <>
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-100">API Keys</h2>
-        <form action={handleGenKey}>
-          <input
-            type="submit"
-            value="Generate New API Key"
-            className="bg-blue-500 hover:bg-blue-600 cursor-pointer text-white px-4 py-2 rounded-md"
-          />
-        </form>
-      </div>
+      <h2 className="text-2xl font-bold text-gray-100 mb-6">API Keys</h2>
 
-      <div className="space-y-4">
-        {apiKeys.length === 0 ? (
-          <p className="text-gray-400">No API keys yet.</p>
-        ) : (
-          apiKeys.map((key) => (
-            <ApiKeyCard
-              key={key.siteKey}
-              apiKey={key}
-              onEdit={async (l) => {
-                "use server";
-                await handleEditKey(key.siteKey, l);
-              }}
-            />
-          ))
-        )}
+      <div className="space-y-8">
+        {keysByApp.map(({ app, keys: appKeys }) => (
+          <div key={app.id} className="space-y-4">
+            <div className="flex justify-between items-center">
+              <h3 className="text-xl font-bold text-gray-100">
+                {app.name ?? "New Application"}
+              </h3>
+              <form action={handleGenKey.bind(null, app.id)}>
+                <input
+                  type="submit"
+                  value="Generate New API Key"
+                  className="bg-blue-500 hover:bg-blue-600 cursor-pointer text-white px-4 py-2 rounded-md"
+                />
+              </form>
+            </div>
+
+            <div className="space-y-4">
+              {appKeys.length === 0 ? (
+                <p className="text-gray-400">No API keys yet.</p>
+              ) : (
+                appKeys.map((key) => (
+                  <ApiKeyCard
+                    key={key.siteKey}
+                    apiKey={key}
+                    appId={app.id}
+                    onEdit={async (l) => {
+                      "use server";
+                      await handleEditKey(app.id, key.siteKey, l);
+                    }}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        ))}
       </div>
     </>
   );

--- a/src/components/api-keys/ApiKeyCard.tsx
+++ b/src/components/api-keys/ApiKeyCard.tsx
@@ -5,15 +5,14 @@ import KeyField from "./KeyField";
 import EditableLabel from "../EditableLabel";
 import { revokeApiKey } from "@/lib/server/api-keys";
 import { ApiKey } from "@/lib/server/types";
-import { useParams } from "next/navigation";
 
 type ApiKeyCardProps = {
   apiKey: ApiKey;
   onEdit?: (label: string) => Promise<void>;
+  appId: string;
 };
 
-export default function ApiKeyCard({ apiKey, onEdit }: ApiKeyCardProps) {
-  const appId = useParams().appId as string;
+export default function ApiKeyCard({ apiKey, onEdit, appId }: ApiKeyCardProps) {
 
   async function revokeKey() {
     await revokeApiKey(appId, apiKey.siteKey);


### PR DESCRIPTION
## Summary
- adapt `ApiKeyCard` to accept an explicit `appId`
- fetch every application and its keys in the API Keys page
- render each application's keys in groups

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881cdc23bc832d9d8ba548d8ea160f