### PR TITLE
UI improvements and confirmation modal

### DIFF
--- a/src/app/console/page.tsx
+++ b/src/app/console/page.tsx
@@ -1,6 +1,7 @@
 import { getApplications, createApplication } from "@/lib/server/console";
 import { redirect } from "next/navigation";
-import { RocketLaunchIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { PlusIcon } from "@heroicons/react/24/outline";
+import Image from "next/image";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 
 export default async function WelcomeConsolePage() {
@@ -11,10 +12,16 @@ export default async function WelcomeConsolePage() {
   }
 
   return (
-    <div className="min-h-[80vh] flex flex-col items-center justify-center px-4">
+    <div className="min-h-[80vh] flex flex-col items-center justify-center px-4 bg-background text-foreground">
       <div className="text-center max-w-2xl mx-auto">
         <div className="mb-8">
-          <RocketLaunchIcon className="h-16 w-16 text-blue-500 mx-auto" />
+          <Image
+            src="/logo.svg"
+            alt="Gotcha logo"
+            width={64}
+            height={64}
+            className="mx-auto"
+          />
         </div>
 
         <h1 className="text-4xl font-bold text-gray-100 mb-4">

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { ReactNode } from "react";
+
+export default function ConfirmModal({
+  open,
+  title,
+  children,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  children?: ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-80 shadow-lg">
+        <h2 className="text-lg font-semibold text-gray-100 mb-4">{title}</h2>
+        {children && <div className="text-gray-300 mb-4">{children}</div>}
+        <div className="flex justify-end space-x-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-600 hover:bg-gray-500 rounded-md text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded-md text-white"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { FormEvent } from "react";
+import { useState, useRef } from "react";
 import EditableLabel from "../EditableLabel";
 import Link from "next/link";
 import { deleteApplication, updateApplication } from "@/lib/server/console";
 import { Application } from "@/lib/server/types";
+import ConfirmModal from "../ConfirmModal";
 
 type ApplicationCardProps = {
   app: Application;
 };
 
 export default function ApplicationCard({ app }: ApplicationCardProps) {
+  const [open, setOpen] = useState(false);
+  const formRef = useRef<HTMLFormElement | null>(null);
 
   return (
     <div className="rounded-xl shadow-sm bg-gray-800 transition-shadow hover:shadow">
@@ -30,22 +33,25 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
         >
           Manage API Keys
         </Link>
-        <form
-          onSubmit={(e: FormEvent<HTMLFormElement>) => {
-            if (!confirm("Are you sure you want to delete this application?")) {
-              e.preventDefault();
-            }
-          }}
-          action={deleteApplication.bind(null, app.id)}
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="text-sm text-red-600 hover:text-red-700 font-medium"
         >
-          <input type="hidden" name="id" value={app.id} />
-          <button
-            type="submit"
-            className="text-sm text-red-600 hover:text-red-700 font-medium"
-          >
-            Delete Application
-          </button>
-        </form>
+          Delete Application
+        </button>
+        <form ref={formRef} action={deleteApplication.bind(null, app.id)} />
+        <ConfirmModal
+          open={open}
+          title="Delete Application"
+          onCancel={() => setOpen(false)}
+          onConfirm={() => {
+            setOpen(false);
+            formRef.current?.requestSubmit();
+          }}
+        >
+          Are you sure you want to delete this application?
+        </ConfirmModal>
       </div>
     </div>
   );

--- a/src/components/sidebar/NavItem.tsx
+++ b/src/components/sidebar/NavItem.tsx
@@ -12,9 +12,7 @@ export type NavItemProps = PropsWithChildren<{
 export default function NavItem({ href, children }: NavItemProps) {
   const pathname = usePathname();
   const hrefPath = typeof href === "string" ? href : href.pathname ?? "";
-  const isActive =
-    pathname === hrefPath ||
-    (hrefPath !== "/" && pathname.startsWith(`${hrefPath}/`));
+  const isActive = pathname === hrefPath;
 
   return (
     <Link


### PR DESCRIPTION
## Summary
- use a custom `ConfirmModal` for deleting applications
- highlight sidebar items only on exact matches
- tweak the empty dashboard page to show dark mode and the Gotcha logo instead of the rocket icon

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688821f747a0832d8e5fb992f3bd3b32