### PR TITLE
Add confirmation prompts for application deletion and API key revocation

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -7,12 +7,14 @@ export default function ConfirmModal({
   children,
   onConfirm,
   onCancel,
+  confirmText = "Delete",
 }: {
   open: boolean;
   title: string;
   children?: ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
+  confirmText?: string;
 }) {
   if (!open) return null;
   return (
@@ -31,7 +33,7 @@ export default function ConfirmModal({
             onClick={onConfirm}
             className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded-md text-white"
           >
-            Delete
+            {confirmText}
           </button>
         </div>
       </div>

--- a/src/components/api-keys/ApiKeyCard.tsx
+++ b/src/components/api-keys/ApiKeyCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { XCircleIcon } from "@heroicons/react/24/outline";
+import { useState, useRef } from "react";
 import KeyField from "./KeyField";
 import EditableLabel from "../EditableLabel";
+import ConfirmModal from "../ConfirmModal";
 import { revokeApiKey } from "@/lib/server/api-keys";
 import { ApiKey } from "@/lib/server/types";
 
@@ -13,10 +15,8 @@ type ApiKeyCardProps = {
 };
 
 export default function ApiKeyCard({ apiKey, onEdit, appId }: ApiKeyCardProps) {
-
-  async function revokeKey() {
-    await revokeApiKey(appId, apiKey.siteKey);
-  }
+  const [open, setOpen] = useState(false);
+  const formRef = useRef<HTMLFormElement | null>(null);
 
   return (
     <div className="bg-gray-800 p-4 rounded-lg shadow-sm">
@@ -26,12 +26,29 @@ export default function ApiKeyCard({ apiKey, onEdit, appId }: ApiKeyCardProps) {
           onEdit={async (l) => onEdit?.(l)}
         />
         <button
-          onClick={revokeKey}
+          type="button"
+          onClick={() => setOpen(true)}
           className="text-red-500 hover:text-red-600 flex items-center"
         >
           <XCircleIcon className="h-5 w-5 mr-1" />
           Revoke
         </button>
+        <form
+          ref={formRef}
+          action={revokeApiKey.bind(null, appId, apiKey.siteKey)}
+        />
+        <ConfirmModal
+          open={open}
+          title="Revoke API Key"
+          confirmText="Revoke"
+          onCancel={() => setOpen(false)}
+          onConfirm={() => {
+            setOpen(false);
+            formRef.current?.requestSubmit();
+          }}
+        >
+          Are you sure you want to revoke this API key?
+        </ConfirmModal>
       </div>
 
       <div className="space-y-3">

--- a/src/components/console/ApplicationCard.tsx
+++ b/src/components/console/ApplicationCard.tsx
@@ -50,7 +50,7 @@ export default function ApplicationCard({ app }: ApplicationCardProps) {
             formRef.current?.requestSubmit();
           }}
         >
-          Are you sure you want to delete this application?
+          {`Are you sure you want to delete the application "${app.name}"?`}
         </ConfirmModal>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show application name in deletion confirmation
- add confirm pop-up for API key revocation
- allow custom confirm button text in `ConfirmModal`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882d100140832d94ad068d7c11f0a7