### PR TITLE
Increase homepage logo size

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ["gotcha.land"],
+  },
+};
 
 export default nextConfig;

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,5 +1,5 @@
 import { getSession } from "@auth0/nextjs-auth0";
-import { RocketLaunchIcon } from "@heroicons/react/24/outline";
+import Image from "next/image";
 import ProfileClient from "@/components/ProfileClient";
 
 export default async function Home() {
@@ -8,7 +8,13 @@ export default async function Home() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4 py-16">
       <main className="text-center space-y-6">
-        <RocketLaunchIcon className="h-16 w-16 text-blue-500 mx-auto" />
+        <Image
+          src="https://gotcha.land/HL_2.png"
+          alt="Gotcha logo"
+          width={192}
+          height={192}
+          className="mx-auto"
+        />
         <h1 className="text-5xl font-bold text-gray-900 dark:text-gray-100">Welcome to Gotcha</h1>
         <p className="text-lg text-gray-600 dark:text-gray-300">
           Secure your applications with challenge-based authentication.


### PR DESCRIPTION
## Summary
- enlarge the Gotcha logo on the public homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882d7a3aa8832d9f103b14e836aed3