### PR TITLE
Fix logout redirect to home

### DIFF
--- a/src/app/api/auth/[auth0]/route.ts
+++ b/src/app/api/auth/[auth0]/route.ts
@@ -1,7 +1,8 @@
 import { handleAuth, handleLogout } from "@auth0/nextjs-auth0";
+import { AUTH0_BASE_URL } from "@/lib/server/env";
 
 export const GET = handleAuth({
   logout: handleLogout({
-    returnTo: "/api/redirect-to-console",
+    returnTo: AUTH0_BASE_URL,
   }),
 });

--- a/src/app/api/redirect-to-console/route.ts
+++ b/src/app/api/redirect-to-console/route.ts
@@ -1,5 +1,0 @@
-import { NextRequest, NextResponse } from "next/server";
-
-export async function GET(req: NextRequest) {
-  return NextResponse.redirect(req.nextUrl.origin + "/console");
-}


### PR DESCRIPTION
## Summary
- redirect logout back to the base URL instead of /console
- remove unused API route for redirect

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f23e2e3c832d925ebb3686daddd1